### PR TITLE
fixed deprecated and now removed `np.int` calls

### DIFF
--- a/laxpy/file.py
+++ b/laxpy/file.py
@@ -24,7 +24,7 @@ class LAXParser:
         stream.seek(15 * 4)
         self.number_cells = struct.unpack('I', stream.read(4))[0]
 
-        for i in range(0, np.int(os.stat(path).st_size/4)):
+        for i in range(0, int(os.stat(path).st_size/4)):
             stream.seek(i*4)
             unpack = struct.unpack('I', stream.read(4))[0]
             self.parsed_bytes.append(unpack)

--- a/laxpy/tree.py
+++ b/laxpy/tree.py
@@ -58,7 +58,7 @@ class LAXTree:
         try:
             parent_lb = self.level_edges[cell_level - 1][0]
             parent_index = (parent_lb + parent_offset) - 1
-            return np.int(parent_index)
+            return int(parent_index)
         except KeyError: # we are at the root
             return 0
 


### PR DESCRIPTION
NumPy v1.20.0 removed the aliases of `np.int` (among others). This hotfix fixes the crash resulting from using laxpy 0.1.9 with that version of NumPy.

More infos:
https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated